### PR TITLE
Service suffix customize

### DIFF
--- a/dubbo.json
+++ b/dubbo.json
@@ -2,5 +2,6 @@
   "output": "./packages/dubbo/src/__tests__/providers",
   "entry": "com.alibaba.dubbo.demo",
   "entryJarPath": "./java/dubbo-demo/dubbo-demo-api/target/dubbo-demo-api-2.5.7.jar",
-  "libDirPath": "./java/dubbo-demo/dubbo-demo-api/target/dependency/"
+  "libDirPath": "./java/dubbo-demo/dubbo-demo-api/target/dependency/",
+  "providerSuffix":"Service"
 }

--- a/packages/interpret-cli/src/ext/index.ts
+++ b/packages/interpret-cli/src/ext/index.ts
@@ -34,6 +34,7 @@ export async function extra(extraParam: IDubboExtInfo): Promise<IExtraResult> {
       extraParam.entry,
       extraParam.entryJarPath,
       extraParam.libDirPath,
+      extraParam.providerSuffix || 'Provider',
     ]);
 
     let err: string = '';
@@ -42,7 +43,6 @@ export async function extra(extraParam: IDubboExtInfo): Promise<IExtraResult> {
     execCmd.stderr.setEncoding("utf8");
     execCmd.stdout.on('data', (rowData:Buffer) => {
       let output = rowData.toString("utf8");
-      console.log(output);
       if (output.includes(startFlag)) {
         let beginIndex = output.indexOf(startFlag) + startFlag.length;
         jarDir = output.substring(beginIndex).trim();
@@ -51,7 +51,6 @@ export async function extra(extraParam: IDubboExtInfo): Promise<IExtraResult> {
 
     execCmd.stderr.on('data', (rowData:Buffer)  => {
       err += rowData.toString("utf8");
-      console.log(err);
     });
 
     execCmd.on('close', code => {

--- a/packages/interpret-cli/src/handle.ts
+++ b/packages/interpret-cli/src/handle.ts
@@ -60,6 +60,10 @@ export class IntepretHandle implements ITypeSearch {
     return this.request.getAst(this.classPath);
   }
 
+  get providerSuffix(): string {
+    return this.request.providerSuffix;
+  }
+
   public async work() {
     await this.prepare();
     await this.doItRecursively();

--- a/packages/interpret-cli/src/request.ts
+++ b/packages/interpret-cli/src/request.ts
@@ -78,6 +78,10 @@ export class Request {
     return this.config.output;
   }
 
+  get providerSuffix(): string{
+    return this.config.providerSuffix;
+  }
+
   registerTypeInfo(typeInfoItem: TypeInfoI) {
     let key = '';
     if (typeInfoItem.classPath) {

--- a/packages/interpret-cli/src/transfer/to-typescript.ts
+++ b/packages/interpret-cli/src/transfer/to-typescript.ts
@@ -46,7 +46,7 @@ export async function toTypescript(
     isAbstract: astJava.isAbstract,
     isInterface: astJava.isInterface,
     isClass: !astJava.isEnum && !astJava.isInterface,
-    isProvider: astJava.name.endsWith('Provider'),
+    isProvider: astJava.name.endsWith(String(intepretHandle.providerSuffix) || 'Provider'),
   };
   intepretHandle.request.registerTypeInfo(typeInfo);
 

--- a/packages/interpret-cli/src/typings.ts
+++ b/packages/interpret-cli/src/typings.ts
@@ -27,6 +27,8 @@ export interface IDubboExtInfo {
   entryJarPath: string;
   //指定jar包依赖的包目录
   libDirPath: string;
+  //provider后缀名可配置
+  providerSuffix: string;
 }
 
 export interface IConfig extends IDubboExtInfo {


### PR DESCRIPTION
### service 后缀名可自定义，
首先代码中的jexpose-1.1.jar包需要通过 [jexopst#7](https://github.com/hsiaosiyuan0/jexpose/pull/7) 的PR才能起作用，在dubbo.json中可传入providerSuffix字段来进行自定义service后缀名。
```js
{
  "output":"./src",
  "entry":"com.bj58.qf.order.service",
  "entryJarPath": "./java/dubbo-demo/qifutong-api/target/order-client-1.1-SNAPSHOT.jar",
  "libDirPath": "./java/dubbo-demo/qifutong-api/target/lib/",
  "providerSuffix":"Service"
}
```
然后在packages/interpret-cli/src/ext/index.ts中,传入第四个参数
```js
 let execCmd = spawn(`java`, [
      '-jar',
      join(__dirname, '../../ext/jexpose-1.1.jar'),
      extraParam.entry,
      extraParam.entryJarPath,
      extraParam.libDirPath,
      extraParam.providerSuffix || 'Provider',
    ]);
```
#### 之后进行to-typescript.ts文件的修改
1，在request.ts文件中定义get providerSuffix
```js
  get providerSuffix(): string{
    return this.config.providerSuffix;
  }
```
2, 传递到handle.ts文件中之后，定义get方法
```js
    get providerSuffix(): string {
    return this.request.providerSuffix;
  }
```
3，最后改变to-typescript.ts中的后缀名的判断
```js
let typeInfo = {
    classPath: astJava.name,
    packagePath: astJava.name.substring(0, lastPointIndex),
    className: astJava.name.substring(lastPointIndex),
    isEnum: astJava.isEnum,
    isAbstract: astJava.isAbstract,
    isInterface: astJava.isInterface,
    isClass: !astJava.isEnum && !astJava.isInterface,
    isProvider: astJava.name.endsWith(String(intepretHandle.providerSuffix) || 'Provider'),
  };
```
整体由@zhcsyncer 指导