### PR TITLE
issue about:

### DIFF
--- a/packages/dubbo/src/zookeeper.ts
+++ b/packages/dubbo/src/zookeeper.ts
@@ -361,8 +361,7 @@ export class ZkRegistry implements IObservable<IRegistrySubscriber> {
       revision: '',
       version: version,
       side: 'consumer',
-      check: 'false',
-      timestamp: Date.now(),
+      check: 'false'
     };
 
     const consumerRoot = `/dubbo/${dubboInterface}/consumers`;


### PR DESCRIPTION
- 在watch zookeeper的时候，会创建consumer，但是判断consumer是否存在中有timestap字段，导致每次时间戳都是不一样的，所以一直会往zookeeper中写入新的consumer，dubbo provider频繁重启会频繁触发watch行为导致写满zookeeper节点空间