### PR TITLE
类域中可选的复杂类型，会造成ts类型检查错误

### DIFF
--- a/packages/interpret-cli/src/transfer/bean/util/transfer.ts
+++ b/packages/interpret-cli/src/transfer/bean/util/transfer.ts
@@ -298,14 +298,14 @@ export function j2Jtj(
       // throw new Error('不可能出现这种的,classPathStr:' + classPath + isClass);
     }
   } else if (typeOptions.isTypeParam(classPath)) {
-    return `${paramRefName}['__fields2java']?${paramRefName}['__fields2java']():${paramRefName}`;
+    return `(${paramRefName}&&${paramRefName}['__fields2java'])?${paramRefName}['__fields2java']():${paramRefName}`;
   } else if (classPath === 'java.math.BigDecimal') {
     log('处理java BigDecimal类型,param %j,schema %j');
     return `${paramRefName}?java.BigDecimal(${paramRefName}.value):null`;
   } else if (classPath === 'java.util.Date') {
     return `${paramRefName}`; //时间类型 js2java可以直接识别;
   } else if (classPath === 'java.lang.Object') {
-    return `${paramRefName}['__fields2java']?${paramRefName}['__fields2java']():${paramRefName}`;
+    return `(${paramRefName}&&${paramRefName}['__fields2java'])?${paramRefName}['__fields2java']():${paramRefName}`;
   } else if (classPath.startsWith('java.lang.')) {
     return `java.${classPath.substring(
       classPath.lastIndexOf('.') + 1,


### PR DESCRIPTION
```
import java from 'js-to-java';

export interface IPager {
  pageCount?: number;
  pageNo?: number;
  obj?: Object;
  start?: number;
  pageSize?: number;
  totalRows?: number;
}

export class Pager {
  constructor(params: IPager) {
    this.pageCount = params.pageCount;
    this.pageNo = params.pageNo;
    this.obj = params.obj;
    this.start = params.start;
    this.pageSize = params.pageSize;
    this.totalRows = params.totalRows;
  }

  pageCount?: number;
  pageNo?: number;
  obj?: Object;
  start?: number;
  pageSize?: number;
  totalRows?: number;

  __fields2java() {
    return {
      $class: 'com.example.page.Pager',
      $: {
        pageCount: java.Integer(this.pageCount),
        pageNo: java.Integer(this.pageNo),
        // obj: this.obj['__fields2java'] ? this.obj['__fields2java']() : this.obj, // [ts] 对象可能为“未定义”。
        obj: (this.obj && this.obj['__fields2java']) ? this.obj['__fields2java']() : this.obj, // 应该确保this.obj存在
        start: java.Integer(this.start),
        pageSize: java.Integer(this.pageSize),
        totalRows: java.Integer(this.totalRows),
      },
    };
  }
}

//generate by interpret-cli dubbo2.js
```