### PR TITLE
support  delivery of attachments from provider to consumer

### DIFF
--- a/packages/dubbo/src/dubbo-url.ts
+++ b/packages/dubbo/src/dubbo-url.ts
@@ -44,7 +44,7 @@ export default class DubboUrl {
     this.port = Number(this._url.port);
     this.path = this._url.pathname.substring(1);
     this.dubboVersion = this._query.dubbo || '';
-    this.version = this._query.version || '0.0.0';
+    this.version = this._query.version || this._query['default.version'] || '0.0.0';
     this.group = this._query.group || '';
   }
 

--- a/packages/dubbo/src/types.ts
+++ b/packages/dubbo/src/types.ts
@@ -123,6 +123,7 @@ export interface IDubboResponse<T> {
   requestId: number;
   err: Error | null;
   res: T | null;
+  resProps: T | null;
 }
 
 export interface IHessianType {


### PR DESCRIPTION
1. 获取默认版本号，再获取类版本号 [issues:64](https://github.com/dubbo/dubbo2.js/issues/64) 
2. 支持dubbo2.6.3 flag：3，4，5d类型。[issues:74](https://github.com/dubbo/dubbo2.js/issues/74) 

备注：  目前获取到attachment数据但是没有返回到方法调用，请补充一下返回

